### PR TITLE
fix: updated azuread versions & dependabot workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -8,5 +8,5 @@
         secrets:
           GITHUB: ${{ secrets.GITHUB }}
         with:
-          tfcheck: 'basic / Check code format'
+          tfcheck: 'complete-example / Check code format'
     ...

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.47.0"
+      version = "~> 2.53.1"
     }
 
   }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.47.0"
+      version = "~> 2.53.1"
     }
 
   }

--- a/examples/pgsql-public/versions.tf
+++ b/examples/pgsql-public/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.47.0"
+      version = "~> 2.53.1"
     }
 
   }

--- a/examples/pgsql-server-replication/versions.tf
+++ b/examples/pgsql-server-replication/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.47.0"
+      version = "~> 2.53.1"
     }
 
   }

--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.47.0"
+      version = "~> 2.53.1"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## what
* Updated `azuread` versions in root & parent module
* Fixed `depandabot` workflow to use complete example 

## why
* `azuread` version was outdated
* `depandabot` workflow was referencing to wrong tf-checks stage