### PR TITLE
fix: Updated the azuread version to use 3.0.2

### DIFF
--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.53.1"
+      version = ">= 3.0.2"
     }
 
   }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.53.1"
+      version = ">= 3.0.2"
     }
 
   }

--- a/examples/pgsql-public/versions.tf
+++ b/examples/pgsql-public/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.53.1"
+      version = ">= 3.0.2"
     }
 
   }

--- a/examples/pgsql-server-replication/versions.tf
+++ b/examples/pgsql-server-replication/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.53.1"
+      version = ">= 3.0.2"
     }
 
   }

--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.53.1"
+      version = ">= 3.0.2"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## what
* Updated the root modules `azuread` versions to >=3.0.2
* Updated the parent module `azuread` versions to >=3.0.2

## why
* ~> instead of >= was required such that the major version is automatically updated by @clouddrove-ci 
