### PR TITLE
Public Network Access & Variablize Server Name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ module "labels" {
 ##-----------------------------------------------------------------------------
 resource "azurerm_postgresql_flexible_server" "main" {
   count                             = var.enabled ? 1 : 0
-  name                              = var.server_name
+  name                              = format("%s-pgsql-flexible-server", module.labels.id)
   resource_group_name               = local.resource_group_name
   location                          = local.location
   administrator_login               = var.admin_username

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ module "labels" {
 ##-----------------------------------------------------------------------------
 resource "azurerm_postgresql_flexible_server" "main" {
   count                             = var.enabled ? 1 : 0
-  name                              = format("%s-pgsql-flexible-server", module.labels.id)
+  name                              = var.server_name
   resource_group_name               = local.resource_group_name
   location                          = local.location
   administrator_login               = var.admin_username
@@ -59,6 +59,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
   create_mode                       = var.create_mode
   geo_redundant_backup_enabled      = var.geo_redundant_backup_enabled
   point_in_time_restore_time_in_utc = var.create_mode == "PointInTimeRestore" ? var.point_in_time_restore_time_in_utc : null
+  public_network_access_enabled     = var.public_network_access_enabled
   source_server_id                  = var.create_mode == "PointInTimeRestore" ? var.source_server_id : null
   storage_mb                        = var.storage_mb
   version                           = var.postgresql_version

--- a/variables.tf
+++ b/variables.tf
@@ -366,3 +366,15 @@ variable "ad_admin_objects_id" {
   default     = null
   description = "azurerm postgresql flexible server active directory administrator's object id"
 }
+
+variable "public_network_access_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable public network access for the PostgreSQL Flexible Server"
+}
+
+variable "server_name" {
+  type        = string
+  default     = "testingserver123"
+  description = "Postgresql flexible server name"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -372,9 +372,3 @@ variable "public_network_access_enabled" {
   default     = false
   description = "Enable public network access for the PostgreSQL Flexible Server"
 }
-
-variable "server_name" {
-  type        = string
-  default     = "testingserver123"
-  description = "Postgresql flexible server name"
-}


### PR DESCRIPTION
Below are the changes -

public_network_access_enabled:
Type: Boolean (default: false). Enables public network access.

server_name:
Type: String (default: "testingserver123"). Sets the PostgreSQL server name.

We have added 2 more attributes to the postgressql flexible server the public_network_access_enabled and made server name flexible.

We have done a testing with these changes and it is working as expected.