### PR TITLE
fix: variablize server name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ module "labels" {
 ##-----------------------------------------------------------------------------
 resource "azurerm_postgresql_flexible_server" "main" {
   count                             = var.enabled ? 1 : 0
-  name                              = format("%s-pgsql-flexible-server", module.labels.id)
+  name                              = var.user_defined_name != null ? var.user_defined_name : format("%s-pgsql-flexible-server", module.labels.id)
   resource_group_name               = local.resource_group_name
   location                          = local.location
   administrator_login               = var.admin_username

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,12 @@ variable "name" {
   description = "Name  (e.g. `app` or `cluster`)."
 }
 
+variable "user_defined_name" {
+  description = "User defined name for the PostgreSQL flexible server"
+  type        = string
+  default     = null
+}
+
 variable "environment" {
   type        = string
   default     = ""


### PR DESCRIPTION
## what
* Variablize server name
* Users can use their desired server name just need to add the name in user_defined_variable

## why
* To make it more dynamic
