### PR TITLE
Fixed HA as per Hashicorp suggestion

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
   depends_on = [azurerm_private_dns_zone_virtual_network_link.main, azurerm_private_dns_zone_virtual_network_link.main2]
 
   lifecycle {
-    ignore_changes = [high_availability.[0].standby_availability_zone]
+    ignore_changes = [high_availability[0].standby_availability_zone]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,10 @@ resource "azurerm_postgresql_flexible_server" "main" {
     }
   }
   depends_on = [azurerm_private_dns_zone_virtual_network_link.main, azurerm_private_dns_zone_virtual_network_link.main2]
+  
+  lifecycle {
+    ignore_changes = [high_availability.0.standby_availability_zone]
+  } 
 }
 
 ##----------------------------------------------------------------------------- 

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
   depends_on = [azurerm_private_dns_zone_virtual_network_link.main, azurerm_private_dns_zone_virtual_network_link.main2]
 
   lifecycle {
-    ignore_changes = [high_availability.0.standby_availability_zone]
+    ignore_changes = [high_availability.[0].standby_availability_zone]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -111,10 +111,10 @@ resource "azurerm_postgresql_flexible_server" "main" {
     }
   }
   depends_on = [azurerm_private_dns_zone_virtual_network_link.main, azurerm_private_dns_zone_virtual_network_link.main2]
-  
+
   lifecycle {
     ignore_changes = [high_availability.0.standby_availability_zone]
-  } 
+  }
 }
 
 ##----------------------------------------------------------------------------- 


### PR DESCRIPTION
Added lifecycle ignore changes to HA as per terraform documentation. (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server#:~:text=A-,high_availability,-block%20supports%20the)

Without these changes terraform will always shows drift in standby_availability_zone
